### PR TITLE
Add "Open in Codeanywhere" button in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,4 +35,12 @@ Relative links should be used.
 
 You can edit and preview the documentation in an online IDE Gitpod. It contains an embedded python HTTP server which starts automatically and shows all changes as you introduce them. To run it with your forked repository, you can navigate to README.md in your fork on GitHub and click the `Open in Gitpod` button below.
 
-[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
+[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/) 
+
+Alternatively, can get this repo running instantly with Codeanywhere by clicking the button below.
+
+[![Open in Codeanywhere](https://codeanywhere.com/img/open-in-codeanywhere-btn.svg)](https://app.codeanywhere.com/#https://github.com/daytonaio/devcontainer-generator)
+
+
+
+


### PR DESCRIPTION
Codeanywhere is a cloud-based development environment that allows developers to open the repo and code in the browser-bassed IDE. It supports a wide range of programming languages, enabling users to work directly within their browser without needing a local setup. With its flexibility and Github integration, it streamlines remote development workflows for individuals and teams.

This PR is adding "Open in Codeanywhere" button to the Readme file. Clicking the button opens the repo in Codeanywhere IDE with a dedicated workspace container running and allows users to start coding in minutes.